### PR TITLE
Update scheduler to use IOC time

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ docker run -d --env-file .env --name secbot secbot-prod
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
-|`SEC_BOT_CRON_TIME`|`06:00`|일일 실행 시각(HH:MM, 로컬)|
+|`SEC_BOT_CRON_TIME`|`06:00`|뉴스/공지 메일 시각 목록(HH:MM, 로컬)|
+|`SEC_BOT_IOC_TIME`|`10:00`|하루 한 번 IOC 메일 및 차단 시각|
 |`SEC_BOT_NEWS_LIMIT`|`10`|실행당 뉴스 헤드라인 개수(1‑50)|
 |`SEC_BOT_ASEC_LIMIT`|`5`|ASEC 게시글 파싱 개수(1‑20)|
 |`SEC_BOT_ENABLE_IPSET`|`true`|ipset 차단 활성화 여부|

--- a/src/secbot/scheduler.py
+++ b/src/secbot/scheduler.py
@@ -2,20 +2,39 @@ import datetime as _dt
 import hashlib
 import os
 from apscheduler.schedulers.background import BackgroundScheduler
+
 from secbot.config import settings
 from secbot.mailer.gmail import (
-    send_security_news,
     send_advisories,
     send_iocs,
+    send_security_news,
 )
-from secbot.fetchers.news import get as fetch_news
 from secbot.fetchers.advisory import get as fetch_advisories
 from secbot.fetchers.asec import get_latest_iocs as fetch_asec_ioc
+from secbot.fetchers.news import get as fetch_news
+from secbot.defense import suricata, suricata_url, suricata_hash
+
 
 def job_ioc():
-    """오전 지정 시간에만 ASEC IOC 전용 메일 발송."""
-    iocs = fetch_asec_ioc()   # {'ip': [...], 'hash': [...], 'url': [...]}
-    send_iocs(iocs, subject=f"[SecBot] Malicious IOC {_dt.date.today():%Y-%m-%d}")
+    """Send ASEC IOC email and trigger Suricata blocks once per day."""
+    iocs = fetch_asec_ioc()
+
+    # Normalise dotted values (e.g. 1[.]2[.]3[.]4)
+    normalized = {
+        "ip": [ip.replace("[.]", ".") for ip in iocs.get("ip", [])],
+        "url": [u.replace("[.]", ".") for u in iocs.get("url", [])],
+        "hash": iocs.get("hash", []),
+    }
+
+    send_iocs(normalized, subject=f"[SecBot] Malicious IOC {_dt.date.today():%Y-%m-%d}")
+
+    if settings.enable_suricata and normalized["ip"]:
+        suricata.block(normalized["ip"])
+    if settings.enable_suricata_url and normalized["url"]:
+        suricata_url.block_urls(normalized["url"])
+    if settings.enable_suricata_hash and normalized["hash"]:
+        suricata_hash.block_hashes(normalized["hash"])
+
 
 def job_news_and_advisories():
     """Fetch news and advisories once per time slot, deduplicate by daily hash record, then send."""
@@ -56,41 +75,47 @@ def job_news_and_advisories():
             sent_hashes.add(h)
 
     # Send emails
-    send_security_news(filtered_news, subject=f"[SecBot] Security News {_dt.date.today():%Y-%m-%d}")
-    send_advisories(filtered_advisories, subject=f"[SecBot] Vulnerability Advisories {_dt.date.today():%Y-%m-%d}")
+    send_security_news(
+        filtered_news, subject=f"[SecBot] Security News {_dt.date.today():%Y-%m-%d}"
+    )
+    send_advisories(
+        filtered_advisories,
+        subject=f"[SecBot] Vulnerability Advisories {_dt.date.today():%Y-%m-%d}",
+    )
 
     # Persist updated hashes back to daily file
     with open(sent_file, "w") as f:
         for h in sent_hashes:
             f.write(f"{h}\n")
 
+
 def start_scheduler():
-    """스케줄러 시작: IOC는 cron_time 리스트의 첫 번째 시간에, 뉴스/취약점은 cron_time 리스트의 모든 시간에 실행."""
+    """Start APScheduler jobs based on configured times."""
     sched = BackgroundScheduler(timezone="Asia/Seoul")
 
-    # IOC 전용 스케줄 (하루에 한 번 첫 번째 시간)
-    ioc_times = settings.cron_time
-    if isinstance(ioc_times, list) and ioc_times:
-        h_ioc, m_ioc = map(int, ioc_times[0].split(":"))
-        sched.add_job(job_ioc, 'cron', hour=h_ioc, minute=m_ioc, id="job_ioc")
+    # IOC 전용 스케줄 (하루에 한 번)
+    try:
+        h_ioc, m_ioc = map(int, settings.ioc_time.split(":"))
+        sched.add_job(job_ioc, "cron", hour=h_ioc, minute=m_ioc, id="job_ioc")
+    except ValueError:
+        pass
 
     # 뉴스 + 취약점 스케줄 (리스트의 모든 시간)
     for idx, t in enumerate(settings.cron_time):
         h, m = map(int, t.split(":"))
         sched.add_job(
-            job_news_and_advisories,
-            'cron',
-            hour=h, minute=m,
-            id=f"job_news_{idx}"
+            job_news_and_advisories, "cron", hour=h, minute=m, id=f"job_news_{idx}"
         )
 
     sched.start()
     return sched
 
+
 if __name__ == "__main__":
     scheduler = start_scheduler()
     try:
         import time
+
         while True:
             time.sleep(60)
     except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
## Summary
- use `SEC_BOT_IOC_TIME` for IOC schedule and enable Suricata blocking in that job
- document the new variable in README

## Testing
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml` missing)*
- `pytest -m "not network"` *(fails: fixture 'sample_boan_rss' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478ffb23c08329ba241f21dac70f92